### PR TITLE
avutil/frame: add missing field to `AVFrame`

### DIFF
--- a/src/avutil/frame.rs
+++ b/src/avutil/frame.rs
@@ -51,6 +51,8 @@ pub struct AVFrame {
 	pub pict_type: AVPictureType,
 	pub sample_aspect_ratio: AVRational,
 
+	pub base: [*mut uint8_t; AV_NUM_DATA_POINTERS],
+
 	pub pts: int64_t,
 	pub pkt_pts: int64_t,
 	pub pkt_dts: int64_t,


### PR DESCRIPTION
This field is marked as deprecated with the deprecation guard `FF_API_AVFRAME_LAVC`. This is defined as `LIBAVUTIL_VERSION_MAJOR < 55`. For ffmpeg 2.7 `LIBAVUTIL_VERSION_MAJOR` is set to 54.
