### PR TITLE
Cargo.toml: add `links = ffmpeg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name    = "ffmpeg-sys"
 version = "2.8.0-5"
 build   = "build.rs"
+links   = "ffmpeg"
 
 authors = ["meh. <meh@schizofreni.co>"]
 license = "WTFPL"


### PR DESCRIPTION
This allows overriding the configuration via `.cargo/config`. Example:

```
[target.x86_64-unknown-linux-gnu.ffmpeg]
rustc-link-search = ["target/native/lib"]
```
