### PR TITLE
Check offset/size of struct fields with unit test; add Travis config; fix AVCodecContext fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ before_install:
   - make distclean
   - popd
 
-script:
+script: |
   # Current Travis Ubuntu version uses libav which doesn't come with libswresample
-  - cargo build --verbose --no-default-features --features "avcodec avfilter avformat avresample swscale"
-  - cargo test  --verbose --no-default-features --features "avcodec avfilter avformat avresample swscale"
+  cargo build --verbose --no-default-features --features "avcodec avfilter avformat avresample swscale" &&
+  cargo test  --verbose --no-default-features --features "avcodec avfilter avformat avresample swscale"
 after_failure:
   - find /usr -type f 2>/dev/null | grep -E 'lib(avcodec/version|avcodec/avcodec).h$' | xargs -I THEFILE -- sh -c 'echo "=== THEFILE ==="; cat THEFILE'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+sudo: required
+dist: trusty
+
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+addons:
+  apt:
+    packages:
+      - build-essential
+before_install:
+  - sudo apt-get update -q
+  # From https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu
+  - sudo apt-get -y --force-yes install autoconf automake build-essential libass-dev libfreetype6-dev libsdl1.2-dev libtheora-dev libtool libva-dev libvdpau-dev libvorbis-dev libxcb1-dev libxcb-shm0-dev libxcb-xfixes0-dev pkg-config texinfo zlib1g-dev
+  - sudo apt-get install yasm
+  - pushd ~
+  - git clone https://github.com/FFmpeg/FFmpeg.git
+  - cd FFmpeg
+  - git checkout release/2.8
+  - mkdir ~/FFmpeg-build
+  - cd ~/FFmpeg-build
+  - ../FFmpeg/configure --disable-ffprobe --disable-ffserver --disable-doc --enable-avresample
+  - make -j
+  - sudo make install
+  - make distclean
+  - popd
+
+script:
+  # Current Travis Ubuntu version uses libav which doesn't come with libswresample
+  - cargo build --verbose --no-default-features --features "avcodec avfilter avformat avresample swscale"
+  - cargo test  --verbose --no-default-features --features "avcodec avfilter avformat avresample swscale"
+after_failure:
+  - find /usr -type f 2>/dev/null | grep -E 'lib(avcodec/version|avcodec/avcodec).h$' | xargs -I THEFILE -- sh -c 'echo "=== THEFILE ==="; cat THEFILE'

--- a/build.rs
+++ b/build.rs
@@ -422,6 +422,7 @@ fn main() {
 		("libavcodec/avcodec.h", Some("avcodec"), "FF_API_MOTION_EST"),
 		("libavcodec/avcodec.h", Some("avcodec"), "FF_API_WITHOUT_PREFIX"),
 		("libavcodec/avcodec.h", Some("avcodec"), "FF_API_CONVERGENCE_DURATION"),
+		("libavcodec/avcodec.h", Some("avcodec"), "FF_API_PRIVATE_OPT"),
 
 		("libavformat/avformat.h", Some("avformat"), "FF_API_LAVF_BITEXACT"),
 		("libavformat/avformat.h", Some("avformat"), "FF_API_LAVF_FRAC"),

--- a/src/avcodec/codec.rs
+++ b/src/avcodec/codec.rs
@@ -935,7 +935,13 @@ pub struct AVCodecContext {
 	pub priv_data: *mut c_void,
 	pub internal: *mut AVCodecInternal,
 	pub opaque: *mut c_void,
+
+	// See https://github.com/FFmpeg/FFmpeg/commit/7404f3bdb90e6a5dcb59bc0a091e2c5c038e557d
+	#[cfg(feature="avcodec_version_greater_than_57_1")]
 	pub bit_rate: int64_t,
+	#[cfg(not(feature="avcodec_version_greater_than_57_1"))]
+	pub bit_rate: c_int,
+
 	pub bit_rate_tolerance: c_int,
 	pub global_quality: c_int,
 	pub compression_level: c_int,

--- a/src/avcodec/codec.rs
+++ b/src/avcodec/codec.rs
@@ -966,6 +966,7 @@ pub struct AVCodecContext {
 	pub b_quant_factor: c_float,
 	#[cfg(feature = "ff_api_rc_strategy")]
 	pub rc_strategy: c_int,
+	#[cfg(feature = "ff_api_private_opt")]
 	pub b_frame_strategy: c_int,
 	pub b_quant_offset: c_float,
 	pub has_b_frames: c_int,

--- a/src/avcodec/codec.rs
+++ b/src/avcodec/codec.rs
@@ -926,7 +926,7 @@ pub struct AVCodecContext {
 	pub log_level_offset: c_int,
 	pub codec_type: AVMediaType,
 	pub codec: *const AVCodec,
-	#[cfg(feature = "ff_api_codec_name")]
+	#[cfg(any(feature="ff_api_codec_name", not(feature="ff_api_codec_name_is_defined")))]
 	pub codec_name: [c_char; 32],
 	pub codec_id: AVCodecID,
 	pub codec_tag: c_uint,

--- a/tests/data/ffmpeg-structs.c
+++ b/tests/data/ffmpeg-structs.c
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 #include <libavcodec/avcodec.h>
 
 int main()

--- a/tests/data/ffmpeg-structs.c
+++ b/tests/data/ffmpeg-structs.c
@@ -24,6 +24,7 @@ int main()
 	p(AVCodecContext, frame_size);
 	p(AVCodecContext, frame_number);
 	p(AVCodecContext, block_align);
+	// p(AVCodecContext, b_frame_strategy);
 
 	return 0;
 }

--- a/tests/data/ffmpeg-structs.c
+++ b/tests/data/ffmpeg-structs.c
@@ -1,0 +1,27 @@
+#include <libavcodec/avcodec.h>
+
+int main()
+{
+	#define p(_struct, _member) { \
+		_struct* p = 0; \
+		unsigned _mysizeof = (unsigned)((size_t)( (&p->_member) + 1 ) - (size_t)( &p->_member )); \
+		printf("[" #_struct "::" #_member " @ %u-%u]\n", (unsigned)offsetof(_struct, _member), _mysizeof); \
+	}
+
+	p(AVCodecContext, av_class);
+	p(AVCodecContext, codec_id);
+	p(AVCodecContext, bit_rate);
+	p(AVCodecContext, bit_rate_tolerance);
+	p(AVCodecContext, width);
+	p(AVCodecContext, height);
+	p(AVCodecContext, coded_width);
+	p(AVCodecContext, pix_fmt);
+	p(AVCodecContext, sample_rate);
+	p(AVCodecContext, channels);
+	p(AVCodecContext, sample_fmt);
+	p(AVCodecContext, frame_size);
+	p(AVCodecContext, frame_number);
+	p(AVCodecContext, block_align);
+
+	return 0;
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,10 +2,10 @@ extern crate libc;
 extern crate ffmpeg_sys;
 
 use std::env;
-use std::fs::{create_dir, File};
+use std::fs::{create_dir, File, symlink_metadata};
 use std::io::Write;
 use std::mem;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
 
@@ -14,8 +14,11 @@ use libc::c_void;
 use ffmpeg_sys::AVCodecContext;
 
 fn output() -> PathBuf {
-	let ret = PathBuf::from("tmp");
-	create_dir(&ret).ok();
+	let mut ret = std::env::current_dir().unwrap();
+	ret.push(&Path::new("tmp"));
+	if symlink_metadata(&ret).is_err() {
+		create_dir(&ret).expect("Failed to create temporary output dir");
+	}
 	ret
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,0 +1,89 @@
+extern crate libc;
+extern crate ffmpeg_sys;
+
+use std::env;
+use std::fs::{create_dir, File};
+use std::io::Write;
+use std::mem;
+use std::path::PathBuf;
+use std::process::Command;
+use std::str;
+
+use libc::c_void;
+
+use ffmpeg_sys::AVCodecContext;
+
+fn output() -> PathBuf {
+	let ret = PathBuf::from("tmp");
+	create_dir(&ret).ok();
+	ret
+}
+
+// Checks if byte offsets in C vs. Rust match
+#[test]
+fn check_struct_byte_offsets() {
+	let out_dir = output();
+	let executable = out_dir.join(if cfg!(windows) { "ffmpeg-structs.exe" } else { "ffmpeg-structs" });
+	let compiler =
+		if cfg!(windows) || env::var("MSYSTEM").unwrap_or("".to_string()).starts_with("MINGW32") {
+			"gcc"
+		}
+		else {
+			"cc"
+		};
+
+	println!("Compiling ffmpeg-structs.c");
+
+	if !Command::new(compiler)
+		.arg("-o").arg(&executable)
+		.arg("tests/data/ffmpeg-structs.c")
+		.status()
+		.expect("ffmpeg-structs compile failed")
+		.success() {
+		panic!("ffmpeg-structs compile failed");
+	}
+
+	println!("Running ffmpeg-structs ({:?})", executable);
+	let stdout_raw = Command::new(&executable).current_dir(&out_dir).output().expect("ffmpeg-structs failed").stdout;
+
+	println!("Writing ffmpeg-structs output file");
+	File::create(out_dir.join("ffmpeg-structs.out")).expect("ffmpeg-structs.out 1").write_all(&stdout_raw[..]).expect("ffmpeg-structs.out 2");
+
+	let stdout = str::from_utf8(stdout_raw.as_slice()).unwrap();
+
+	// This should check same fields as ffmpeg-structs.c
+	macro_rules! p {
+		($the_struct:ident, $the_field:ident) => {{
+			println!("Test field size for {}::{}", stringify!($the_struct), stringify!($the_field));
+			let ptr : &$the_struct = unsafe { mem::uninitialized() };
+			let expected = format!("[{}::{} @ {}-{}]", stringify!($the_struct), stringify!($the_field), (&ptr.$the_field) as *const _ as usize - ptr as *const _ as usize, mem::size_of_val(&ptr.$the_field));
+
+			if stdout.find(&expected).is_none() {
+				let actual_prefix = format!("[{}::{} @ ", stringify!($the_struct), stringify!($the_field));
+				let mut actual = String::from("not found");
+				for line in stdout.lines() {
+					if line.find(&actual_prefix).is_some() {
+						actual = line.to_string();
+						break
+					}
+				}
+				panic!("Struct field position as specified in Rust code ({}) is different from C ({})", expected, actual);
+			}
+		}};
+	}
+
+	p!(AVCodecContext, av_class);
+	p!(AVCodecContext, codec_id);
+	p!(AVCodecContext, bit_rate);
+	p!(AVCodecContext, bit_rate_tolerance);
+	p!(AVCodecContext, width);
+	p!(AVCodecContext, height);
+	p!(AVCodecContext, coded_width);
+	p!(AVCodecContext, pix_fmt);
+	p!(AVCodecContext, sample_rate);
+	p!(AVCodecContext, channels);
+	p!(AVCodecContext, sample_fmt);
+	p!(AVCodecContext, frame_size);
+	p!(AVCodecContext, frame_number);
+	p!(AVCodecContext, block_align);
+}


### PR DESCRIPTION
Summary:
- FFmpeg feature checks are now done in only one source file compilation, which is much faster.
- Added Travis CI config. I recommend to turn it on for your repository, as well. They still use Ubuntu 14.04 which only has libav packaged, so I'm installing FFmpeg from source (branch release/2.8, could be changed in the future or tested for multiple versions) which prolongs builds to 10+ minutes.
- Added unit test which checks field offsets/sizes in Rust declaration vs. C.
- The test revealed the solution for our discussion about `bit_rate` (#17), and some other fields that have changed in `AVCodecContext`. More struct checks should be added in the future. Right now, the `p(structname, fieldname)` lines have to exist in the Rust unit test _and_ ffmpeg-structs.c, but maybe I can simplify at some point.
