### PR TITLE
Multi-cpu build support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ keywords    = ["audio", "video"]
 [dependencies]
 libc = "0.2"
 
+[build-dependencies]
+num_cpus = "0.2.11"
+
 [features]
 default  = ["avcodec", "avdevice", "avfilter", "avformat", "avresample", "swresample", "swscale"]
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+extern crate num_cpus;
+
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, Write};
@@ -207,7 +209,9 @@ fn build() -> io::Result<()> {
 	}
 
 	// run make
-	if !try!(Command::new("make").current_dir(&source()).status()).success() {
+	if !try!(Command::new("make")
+		.arg("-j").arg(num_cpus::get().to_string())
+		.current_dir(&source()).status()).success() {
 		return Err(io::Error::new(io::ErrorKind::Other, "make failed"));
 	}
 


### PR DESCRIPTION
Hi, I got tired of waiting on ffmpeg building so I added the num_cpus crate as a dep to detect cpus and passed the value further to `make -j`.

Is this interesting for anyone?
