### PR TITLE
avcodec: fix field sizes for 3.x

### DIFF
--- a/src/avcodec/codec.rs
+++ b/src/avcodec/codec.rs
@@ -670,7 +670,7 @@ pub struct AVPacket {
 	pub flags: c_int,
 	pub side_data: *mut AVPacketSideData,
 	pub side_data_elems: c_int,
-	pub duration: c_int,
+	pub duration: int64_t,
 	#[cfg(feature = "ff_api_destruct_packet")]
 	pub destruct: Option<extern fn(*mut AVPacket)>,
 	#[cfg(feature = "ff_api_destruct_packet")]

--- a/src/avcodec/codec.rs
+++ b/src/avcodec/codec.rs
@@ -932,7 +932,7 @@ pub struct AVCodecContext {
 	pub priv_data: *mut c_void,
 	pub internal: *mut AVCodecInternal,
 	pub opaque: *mut c_void,
-	pub bit_rate: c_int,
+	pub bit_rate: int64_t,
 	pub bit_rate_tolerance: c_int,
 	pub global_quality: c_int,
 	pub compression_level: c_int,


### PR DESCRIPTION
As discussed in #24 
