### PR TITLE
Removed secondary 'dist' from the include search path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -291,7 +291,7 @@ fn check_features(infos: &Vec<(&'static str, Option<&'static str>, &'static str)
 		};
 
 	if !Command::new(compiler).current_dir(&out_dir)
-		.arg("-I").arg(search().join("dist").join("include").to_string_lossy().into_owned())
+		.arg("-I").arg(search().join("include").to_string_lossy().into_owned())
 		.arg("-o").arg(&executable)
 		.arg("check.c")
 		.status().expect("Command failed").success() {


### PR DESCRIPTION
I had to remove this to fix the build - the resulting path was:
OUT_DIR/dist/dist/include
