### PR TITLE
Two helpful changes I found while implementing my client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ build-license-version3 = ["build"]
 # misc
 build-pic  = ["build"]
 build-zlib = ["build"]
+build-libva = ["build"]
 
 # ssl
 build-lib-gnutls  = ["build"]

--- a/build.rs
+++ b/build.rs
@@ -291,7 +291,7 @@ fn check_features(infos: &Vec<(&'static str, Option<&'static str>, &'static str)
 		};
 
 	if !Command::new(compiler).current_dir(&out_dir)
-		.arg("-I").arg(search().join("dist").join("include").to_string_lossy().into_owned())
+		.arg("-I").arg(search().join("include").to_string_lossy().into_owned())
 		.arg("-o").arg(&executable)
 		.arg("check.c")
 		.status().expect("Command failed").success() {

--- a/build.rs
+++ b/build.rs
@@ -348,6 +348,10 @@ fn main() {
 		if env::var("CARGO_FEATURE_BUILD_ZLIB").is_ok() && cfg!(target_os = "linux") {
 			println!("cargo:rustc-link-lib=z");
 		}
+		
+		if env::var("CARGO_FEATURE_BUILD_LIBVA").is_ok() && cfg!(target_os = "linux") {
+			println!("cargo:rustc-link-lib=va");
+		}
 
 		if fs::metadata(&search().join("lib").join("libavutil.a")).is_ok() {
 			return;

--- a/src/avcodec/defaults.rs
+++ b/src/avcodec/defaults.rs
@@ -1,0 +1,44 @@
+use std::ptr;
+use avcodec::AVPacket;
+
+impl Default for AVPacket {
+	#[cfg(feature = "ff_api_destruct_packet")]
+	fn default() -> AVPacket {
+		AVPacket {
+			buf: ptr::null_mut(),
+			pts: 0,
+			dts: 0,
+			data: ptr::null_mut(),
+			size: 0,
+			stream_index: 0,
+			flags: 0,
+			side_data: ptr::null_mut(),
+			side_data_elems: 0,
+			duration: 0,
+			destruct: None,
+			private: ptr::null_mut(),
+			pos: 0,
+			convergence_duration: 0,
+		}
+	}
+	
+	#[cfg(not(feature = "ff_api_destruct_packet"))]
+	fn default() -> AVPacket {
+		AVPacket {
+			buf: ptr::null_mut(),
+			pts: 0,
+			dts: 0,
+			data: ptr::null_mut(),
+			size: 0,
+			stream_index: 0,
+			flags: 0,
+			side_data: ptr::null_mut(),
+			side_data_elems: 0,
+			duration: 0,
+			//destruct:
+			//private:
+			pos: 0,
+			convergence_duration: 0,
+		}
+	}
+}

--- a/src/avcodec/mod.rs
+++ b/src/avcodec/mod.rs
@@ -15,6 +15,8 @@ pub use self::fft::*;
 pub use self::fft::RDFTransformType::*;
 pub use self::fft::DCTTransformType::*;
 
+mod defaults;
+
 mod dv_profile;
 pub use self::dv_profile::*;
 


### PR DESCRIPTION
Take these with a grain of salt as I'm very new to rust:

```
Added libva build feature (linux only)

Added defaults for AVPacket (normally zero-initialized)
```

There are also a number of changes required to update the build configuration for 3.0; I am not using most of these but I've identified them and will check that in when I can get around to verifying everything.
