### PR TITLE
Fix static build problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - pushd ~
   - git clone https://github.com/FFmpeg/FFmpeg.git
   - cd FFmpeg
-  - git checkout release/3.0
+  - git checkout release/3.2
   - mkdir ~/FFmpeg-build
   - cd ~/FFmpeg-build
   - ../FFmpeg/configure --disable-ffprobe --disable-ffserver --disable-doc --enable-avresample

--- a/build.rs
+++ b/build.rs
@@ -71,6 +71,8 @@ fn build() -> io::Result<()> {
 	configure.arg("--enable-static");
 	configure.arg("--disable-shared");
 
+	configure.arg("--enable-pic");
+
 	// do not build programs since we don't need them
 	configure.arg("--disable-programs");
 


### PR DESCRIPTION
This PR adds `--enable-pic` option to `configure` to resolve `recompile with -fPIC` error on Ubuntu.
It also fixes ffmpeg version used by Travis.