### PR TITLE
Struct definition for AVDictionary

### DIFF
--- a/src/avutil/dict.rs
+++ b/src/avutil/dict.rs
@@ -13,7 +13,10 @@ pub struct AVDictionaryEntry {
 	pub value: *mut c_char,
 }
 
-pub type AVDictionary = c_void;
+pub struct AVDictionary {
+    pub count: usize,
+    pub elems: *mut AVDictionaryEntry
+}
 
 extern {
 	pub fn av_dict_get(m: *const AVDictionary, key: *const c_char, prev: *const AVDictionaryEntry, flags: c_int) -> *mut AVDictionaryEntry;


### PR DESCRIPTION
Handling the null pointer is a pain with rust ffi. I don't think anything should break by using the correct struct definition instead.