### PR TITLE
Add libavutil/pixdesc.h to binding generation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -494,6 +494,11 @@ fn main() {
 
         pkg_config::Config::new()
             .statik(statik)
+            .probe("libavfilter")
+            .unwrap();
+
+        pkg_config::Config::new()
+            .statik(statik)
             .probe("libavdevice")
             .unwrap();
 

--- a/build.rs
+++ b/build.rs
@@ -882,6 +882,7 @@ fn main() {
         .header(search_include(&include_paths, "libavutil/avutil.h"))
         .header(search_include(&include_paths, "libavutil/pixfmt.h"))
         .header(search_include(&include_paths, "libavutil/time.h"))
+        .header(search_include(&include_paths, "libavutil/pixdesc.h"))
 
         .header(search_include(&include_paths, "libavfilter/buffersrc.h"))
         .header(search_include(&include_paths, "libavfilter/avfilter.h"))


### PR DESCRIPTION
New functionality by @YaLTeR requires it.