### PR TITLE
Add motion_vector.h to binding generation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -888,6 +888,7 @@ fn main() {
         .header(search_include(&include_paths, "libavutil/pixfmt.h"))
         .header(search_include(&include_paths, "libavutil/time.h"))
         .header(search_include(&include_paths, "libavutil/pixdesc.h"))
+        .header(search_include(&include_paths, "libavutil/motion_vector.h"))
 
         .header(search_include(&include_paths, "libavfilter/buffersrc.h"))
         .header(search_include(&include_paths, "libavfilter/avfilter.h"))


### PR DESCRIPTION
Fixes https://github.com/meh/rust-ffmpeg-sys/issues/46

@meh I think we need a strategy here. Do I add all .h files from ffmpeg to binding generation so that all structures become available or add bit by bit like this, what is needed? In first pull request I've added only those structures, which were used by rust-ffmpeg.