### PR TITLE
Fix for platforms which disallow indirect linking

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -504,6 +504,21 @@ fn main() {
 
         pkg_config::Config::new()
             .statik(statik)
+            .probe("libavutil")
+            .unwrap();
+
+        pkg_config::Config::new()
+            .statik(statik)
+            .probe("libswscale")
+            .unwrap();
+
+        pkg_config::Config::new()
+            .statik(statik)
+            .probe("libswresample")
+            .unwrap();
+
+        pkg_config::Config::new()
+            .statik(statik)
             .probe("libavcodec")
             .unwrap()
             .include_paths


### PR DESCRIPTION
On Fedora 26, I had to add more explicit libs to pkg-config in order to build rust-ffmpeg examples or any project based on rust-ffmpeg. Example of error message without this fix:
```
note: /usr/bin/ld: /home/fengalin/Projects/rust-ffmpeg/target/debug/deps/libffmpeg-c448b252bca789ad.rlib(ffmpeg-c448b252bca789ad.0.o): undefined reference to symbol «av_frame_free@@LIBAVUTIL_55»
          //usr/lib64/libavutil.so.55: error adding symbols: DSO missing from command line
          collect2: error: ld returned 1 exit status
```
Note that I also had to use this:
```
export C_INCLUDE_PATH=/usr/lib/gcc/x86_64-redhat-linux/7/include/
```
but I'm not quite sure how to fix it properly. When I don't use this export, I get the following output:
```
[...]
HOST_CC = None
CC = None
HOST = Some("x86_64-unknown-linux-gnu")
TARGET = Some("x86_64-unknown-linux-gnu")
HOST = Some("x86_64-unknown-linux-gnu")
CFLAGS_x86_64-unknown-linux-gnu = None
CFLAGS_x86_64_unknown_linux_gnu = None
HOST_CFLAGS = None
CFLAGS = None
PROFILE = Some("debug")
/usr/include/limits.h:124:16: fatal error: 'limits.h' file not found, err: true

--- stderr
/usr/include/limits.h:124:16: fatal error: 'limits.h' file not found
thread 'main' panicked at 'Unable to generate bindings: ()', /checkout/src/libcore/result.rs:860
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```