### PR TITLE
Couple small fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ffmpeg-sys"
-version = "3.3.2"
+version = "3.3.3"
 build   = "build.rs"
 links   = "ffmpeg"
 
@@ -16,7 +16,7 @@ libc = "0.2"
 
 [build-dependencies]
 num_cpus = "1"
-gcc = "0.3"
+cc = "1"
 pkg-config = "0.3"
 bindgen    = "0.30"
 regex      = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 extern crate bindgen;
-extern crate gcc;
+extern crate cc;
 extern crate num_cpus;
 extern crate pkg_config;
 extern crate regex;
@@ -24,12 +24,12 @@ impl ParseCallbacks for IntCallbacks {
         let codec_flag = Regex::new(r"^AV_CODEC_FLAG").unwrap();
         let error_max_size = Regex::new(r"^AV_ERROR_MAX_STRING_SIZE").unwrap();
 
-        if value >= i64::min_value() as i64 && value <= i64::max_value() as i64 &&
-            ch_layout.is_match(_name)
+        if value >= i64::min_value() as i64 && value <= i64::max_value() as i64
+            && ch_layout.is_match(_name)
         {
             Some(IntKind::ULongLong)
-        } else if value >= i32::min_value() as i64 && value <= i32::max_value() as i64 &&
-            (codec_cap.is_match(_name) || codec_flag.is_match(_name))
+        } else if value >= i32::min_value() as i64 && value <= i32::max_value() as i64
+            && (codec_cap.is_match(_name) || codec_flag.is_match(_name))
         {
             Some(IntKind::UInt)
         } else if error_max_size.is_match(_name) {
@@ -341,7 +341,7 @@ version_minor=version_minor));
     ).expect("Write failed");
 
     let executable = out_dir.join(if cfg!(windows) { "check.exe" } else { "check" });
-    let mut compiler = gcc::Build::new().get_compiler().to_command();
+    let mut compiler = cc::Build::new().get_compiler().to_command();
 
     for dir in include_paths {
         compiler.arg("-I");
@@ -406,8 +406,8 @@ version_minor=version_minor));
                 );
                 let pos = stdout
                     .find(&search_str)
-                    .expect("Variable not found in output") +
-                    search_str.len();
+                    .expect("Variable not found in output")
+                    + search_str.len();
 
                 if &stdout[pos..pos + 1] == "1" {
                     println!(
@@ -856,7 +856,7 @@ fn main() {
         create_dir(&tmp).expect("Failed to create temporary output dir");
     }
     let mut f = File::create(tmp.join(".build")).expect("Filed to create .build");
-    let tool = gcc::Build::new().get_compiler();
+    let tool = cc::Build::new().get_compiler();
     write!(f, "{}", tool.path().to_string_lossy().into_owned()).expect("failed to write cmd");
     for arg in tool.args() {
         write!(f, " {}", arg.to_str().unwrap()).expect("failed to write arg");

--- a/src/avutil/rational.rs
+++ b/src/avutil/rational.rs
@@ -8,14 +8,14 @@ pub unsafe fn av_make_q(num: c_int, den: c_int) -> AVRational {
 
 #[inline(always)]
 pub unsafe fn av_cmp_q(a: AVRational, b: AVRational) -> c_int {
-    let tmp: int64_t = a.num as int64_t * b.den as int64_t - b.num as int64_t * a.den as int64_t;
+    let tmp: int64_t = i64::from(a.num) * i64::from(b.den) -i64::from(b.num) * i64::from(a.den);
 
     if tmp != 0 {
-        (((tmp ^ a.den as int64_t ^ b.den as int64_t) >> 63) | 1) as c_int
+        (((tmp ^ i64::from(a.den) ^ i64::from(b.den)) >> 63) | 1) as c_int
     } else if b.den != 0 && a.den != 0 {
         0
     } else if a.num != 0 && b.num != 0 {
-        ((a.num as int64_t >> 31) - (b.num as int64_t >> 31)) as c_int
+        ((i64::from(a.num) >> 31) - (i64::from(b.num) >> 31)) as c_int
     } else {
         c_int::min_value()
     }
@@ -23,7 +23,7 @@ pub unsafe fn av_cmp_q(a: AVRational, b: AVRational) -> c_int {
 
 #[inline(always)]
 pub unsafe fn av_q2d(a: AVRational) -> c_double {
-    a.num as c_double / a.den as c_double
+    f64::from(a.num) / f64::from(a.den)
 }
 
 #[inline(always)]


### PR DESCRIPTION
-Fix version number. 3.3.3 was released to crates.io, but wasn't updated in repo
-Move from gcc crate to cc crate, as it was renamed.
-Fix clippy lint suggestions about type conversions (https://rust-lang-nursery.github.io/rust-clippy/v0.0.164/index.html#cast_lossless).