### PR TITLE
Updated to match v3.4 location of FFmpeg intermediate build files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "ffmpeg-sys"
-version = "3.3.3"
+version = "3.4.0"
 build   = "build.rs"
 links   = "ffmpeg"
 

--- a/build.rs
+++ b/build.rs
@@ -480,7 +480,7 @@ fn main() {
 
         // Check additional required libraries.
         {
-            let config_mak = source().join("config.mak");
+            let config_mak = source().join("ffbuild/config.mak");
             let file = File::open(config_mak).unwrap();
             let reader = BufReader::new(file);
             let extra_libs = reader


### PR DESCRIPTION
This was all that was needed to get the library building for FFmpeg 3.4. I was able to test using my own unpublished code and things seemed to work properly.