### PR TITLE
Robust clone

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -123,6 +123,7 @@ fn fetch() -> io::Result<()> {
     let status = Command::new("git")
             .current_dir(&output_base_path)
             .arg("clone")
+            .arg("--depth=1")
             .arg("-b")
             .arg(format!("release/{}", version()))
             .arg("https://github.com/FFmpeg/FFmpeg")

--- a/build.rs
+++ b/build.rs
@@ -117,13 +117,16 @@ fn search() -> PathBuf {
 }
 
 fn fetch() -> io::Result<()> {
+    let output_base_path = output();
+    let clone_dest_dir = format!("ffmpeg-{}", version());
+    let _ = std::fs::remove_dir_all(output_base_path.join(&clone_dest_dir));
     let status = Command::new("git")
-            .current_dir(&output())
+            .current_dir(&output_base_path)
             .arg("clone")
             .arg("-b")
             .arg(format!("release/{}", version()))
             .arg("https://github.com/FFmpeg/FFmpeg")
-            .arg(format!("ffmpeg-{}", version()))
+            .arg(&clone_dest_dir)
             .status()?;
 
     if status.success() {


### PR DESCRIPTION
The build may fail if the directory already exists, e.g. if a previous clone was interrupted before it finished.