### PR TITLE
Fix static linking errors caused by auto-enabled unsupported libraries

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -167,6 +167,9 @@ fn build() -> io::Result<()> {
 
     configure.arg("--enable-pic");
 
+    // stop autodetected libraries enabling themselves, causing linking errors
+    configure.arg("--disable-autodetect");
+
     // do not build programs since we don't need them
     configure.arg("--disable-programs");
 


### PR DESCRIPTION
`./configure` has a lot of autodetected features, like SDL2 or LZMA support. 

These enable themselves unexpectedly, and then cause issues at linking time, because the script is not prepared to provide all these random libraries.