### PR TITLE
Fix incorrect static inline function

### DIFF
--- a/src/avutil/rational.rs
+++ b/src/avutil/rational.rs
@@ -15,7 +15,7 @@ pub unsafe fn av_cmp_q(a: AVRational, b: AVRational) -> c_int {
     } else if b.den != 0 && a.den != 0 {
         0
     } else if a.num != 0 && b.num != 0 {
-        ((i64::from(a.num) >> 31) - (i64::from(b.num) >> 31)) as c_int
+        (a.num >> 31) - (b.num >> 31)
     } else {
         c_int::min_value()
     }


### PR DESCRIPTION
```c
/**
 * Compare two rationals.
 *
 * @param a First rational
 * @param b Second rational
 *
 * @return One of the following values:
 *         - 0 if `a == b`
 *         - 1 if `a > b`
 *         - -1 if `a < b`
 *         - `INT_MIN` if one of the values is of the form `0 / 0`
 */
static inline int av_cmp_q(AVRational a, AVRational b){
    const int64_t tmp= a.num * (int64_t)b.den - b.num * (int64_t)a.den;

    if(tmp) return (int)((tmp ^ a.den ^ b.den)>>63)|1;
    else if(b.den && a.den) return 0;
    else if(a.num && b.num) return (a.num>>31) - (b.num>>31);
    else                    return INT_MIN;
}
```