### PR TITLE
Fix type issue for compilation targeting windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1076,6 +1076,9 @@ fn thread_main() {
         .ctypes_prefix("libc")
         // https://github.com/rust-lang/rust-bindgen/issues/550
         .blocklist_type("max_align_t")
+        // Issue on aligned and packed struct. Related to:
+        // https://github.com/rust-lang/rust-bindgen/issues/1538
+        .opaque_type("__mingw_ldbl_type_t")
         // these are never part of ffmpeg API
         .blocklist_function("_.*")
         // Rust doesn't support long double, and bindgen can't skip it


### PR DESCRIPTION
# Issue
When trying to compile for the target `x86_64-pc-windows-gnu`, it gives the following error:

```
localhost% PKG_CONFIG_ALLOW_CROSS=1 cargo build --release --target=x86_64-pc-windows-gnu
   Compiling ffmpeg-sys v4.3.2 (/home/_/Code/rust-ffmpeg-sys)
error[E0587]: type has conflicting packed and align representation hints
    --> /home/_/Code/rust-ffmpeg-sys/target/x86_64-pc-windows-gnu/release/build/ffmpeg-sys-b96fa4f58482532a/out/bindings.rs:1930:1
     |
1930 | / pub union __mingw_ldbl_type_t {
1931 | |     pub x: u128,
1932 | |     pub lh: __mingw_ldbl_type_t__bindgen_ty_1,
1933 | | }
     | |_^
```

It seems that this is a bindgen (or rust) related [issue](https://github.com/rust-lang/rust-bindgen/issues/1538), but this fix does it for me. Not really sure if this type should be blocklisted instead, but opaque may be a less breaking solution.

# Environment
I'm actually compiling from a rustup installed stable toolchain on an archlinux system.